### PR TITLE
Use magic methods for the session store.

### DIFF
--- a/src/Bluz/Session/Store/AbstractStore.php
+++ b/src/Bluz/Session/Store/AbstractStore.php
@@ -66,21 +66,17 @@ abstract class AbstractStore
     public abstract function start();
 
     /**
-     * set
-     *
      * @param string $key
      * @param mixed $value
-     * @return boolean
+     * @return void
      */
-    public abstract function set($key, $value);
+    public abstract function __set($key, $value);
 
     /**
-     * get
-     *
      * @param string $key
      * @return mixed
      */
-    public abstract function get($key);
+    public abstract function __get($key);
 
     /**
      * destroy

--- a/src/Bluz/Session/Store/ArrayStore.php
+++ b/src/Bluz/Session/Store/ArrayStore.php
@@ -59,6 +59,7 @@ class ArrayStore extends AbstractStore
      * @param string $key
      * @param mixed $value
      * @return boolean
+     * @deprecated
      */
     public function set($key, $value)
     {
@@ -66,14 +67,33 @@ class ArrayStore extends AbstractStore
     }
 
     /**
+     * @param string $key
+     * @param mixed $value
+     */
+    public function __set($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    /**
      * __get
      *
      * @param string $key
      * @return mixed
+     * @deprecated
      */
     public function get($key)
     {
         return isset($this->store[$this->namespace][$key])?$this->store[$this->namespace][$key]:null;
+    }
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
     }
 
     /**

--- a/src/Bluz/Session/Store/SessionStore.php
+++ b/src/Bluz/Session/Store/SessionStore.php
@@ -90,9 +90,9 @@ class SessionStore extends AbstractStore
     /**
      * set
      *
-     * @param string $key
-     * @param mixed  $value
-     * @return bool|void
+     * @param $key
+     * @param $value
+     * @deprecated
      */
     public function set($key, $value)
     {
@@ -101,10 +101,20 @@ class SessionStore extends AbstractStore
     }
 
     /**
+     * @param $key
+     * @param $value
+     */
+    public function __set($key, $value)
+    {
+        $this->set($key, $value);
+    }
+
+    /**
      * get
      *
      * @param string $key
      * @return mixed
+     * @deprecated
      */
     public function get($key)
     {
@@ -113,6 +123,15 @@ class SessionStore extends AbstractStore
             return null;
         }
         return $_SESSION[$this->namespace][$key];
+    }
+
+    /**
+     * @param string $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return $this->get($key);
     }
 
 


### PR DESCRIPTION
Use magic methods __set/__get instead of set/get.
The methods set/get were marked as deprecated.
