### PR TITLE
Unnecessary check was removed.

### DIFF
--- a/src/Bluz/EventManager/Event.php
+++ b/src/Bluz/EventManager/Event.php
@@ -106,7 +106,7 @@ class Event
         if (!is_array($params) && !is_object($params)) {
             throw new EventException(sprintf(
                 'Event parameters must be an array or object; received "%s"',
-                (is_object($params) ? get_class($params) : gettype($params))
+                gettype($params)
             ));
         }
 


### PR DESCRIPTION
If this condition is true, the params can't be object.
