### PR TITLE
Replaced array_diff with array_diff_assoc in doUpdate method of \Bluz\Db\Row

### DIFF
--- a/src/Bluz/Db/Row.php
+++ b/src/Bluz/Db/Row.php
@@ -290,7 +290,7 @@ class Row
          * Compare the data to the modified fields array to discover
          * which columns have been changed.
          */
-        $diffData = array_diff($this->toArray(), $this->clean);
+        $diffData = array_diff_assoc($this->toArray(), $this->clean);
 
         /**
          * Execute the UPDATE (this may throw an exception)


### PR DESCRIPTION
Changed doUpdate method according to a little weird result shown in this gist - https://gist.github.com/247d95547d15bb85ad9b. There is a difference between array_diff and array_diff_assoc in 2 different situations.
