### PR TITLE
Added check for non-bluz session init

### DIFF
--- a/src/Bluz/Session/Store/SessionStore.php
+++ b/src/Bluz/Session/Store/SessionStore.php
@@ -75,6 +75,8 @@ class SessionStore extends AbstractStore
             if (headers_sent($filename, $linenum)) {
                 throw new SessionException("Session must be started before any output has been sent to the browser;"
                     . " output started in {$filename}/{$linenum}");
+            } else if (session_id() !== '') {
+                throw new SessionException("Session has been started already");
             } else {
                 $this->started = session_start();
                 if (!isset($_SESSION[$this->namespace])) {


### PR DESCRIPTION
Выведем в начале метода start следующее:
$this->started; //флаг, установлена ли сессия или нет
headers_sent(); // были ли отосланы заголовки и где
session_id(); //идентификатор текущей сессии
isset($_SESSION); //существует ли массив SESSION

Проверим эти значения, например, во время процедуры авторизации:
var_dump($this->started); // false 
var_dump(headers_sent()); // false
var_dump(session_id()); // ''
var_dump(isset($_SESSION)); // false
Действительно, сессия еще не была инициализирована, поэтому все значения отсутствуют.

Но, допустим, до "блюзовского" старта сессии у нас "затесался" session_start(). К примеру, его использует Facebook SDK для своих целей.
Тогда результат неожиданный.
var_dump($this->started); // false 
var_dump(headers_sent()); // false
var_dump(session_id()); // '%вполне_существующий_идентификатор%'
var_dump(isset($_SESSION)); // true
Сессия стартовала после session_start(), что определило session_id и _SESSION. Но this->started (что вполне логично) остался false.

Идем дальше. Если this->started === false, то идет проверка на headers_sent(). Если она вернут true, то бросаем исключение. Если ложь - инициализируем сессию.
Но headers_sent() у нас вернет false при уже созданной сессии и дальнейшие действия повлекут ошибку. Поэтому логично добавить еще одну проверку, которую я описал в реквесте.

Если session_start() у нас идет после блюзовского запуска сессии, то все нормально (в текущей версии и в предлагаемой мной).
