### PR TITLE
Fixed LIKE filter in Grid\Source\ArraySource

### DIFF
--- a/src/Grid/Source/ArraySource.php
+++ b/src/Grid/Source/ArraySource.php
@@ -92,7 +92,7 @@ class ArraySource extends AbstractSource
                                     }
                                     break;
                                 case Grid\Grid::FILTER_LIKE:
-                                    if (preg_match('/'.$value.'/', $row[$column])) {
+                                    if (!preg_match('/'.$value.'/', $row[$column])) {
                                         return false;
                                     }
                                     break;


### PR DESCRIPTION
In old version we got the whole haystack exclude the needle :) 
