### PR TITLE
Fix file cache race condition

### DIFF
--- a/src/Cache/Adapter/FileBase.php
+++ b/src/Cache/Adapter/FileBase.php
@@ -107,4 +107,25 @@ abstract class FileBase extends AbstractAdapter
 
         return $path . $this->extension;
     }
+
+    /**
+     * Write string to the file in an atomic way
+     *
+     * @param string $fileName
+     * @param string $content
+     * @return bool|int The number of bytes that were written to the file, or false on failure
+     */
+    protected function writeFile($fileName, $content)
+    {
+        $tempFileName = $fileName . uniqid('', true) . '.temp';
+        $bytes = file_put_contents($tempFileName, $content);
+        if ($bytes !== false) {
+            if (rename($tempFileName, $fileName)) {
+                return $bytes;
+            }
+            @unlink($tempFileName);
+        }
+
+        return false;
+    }
 }

--- a/src/Cache/Adapter/PhpFile.php
+++ b/src/Cache/Adapter/PhpFile.php
@@ -118,7 +118,7 @@ class PhpFile extends FileBase
         $cacheEntry = var_export($cacheEntry, true);
         $code = sprintf('<?php return %s;', $cacheEntry);
 
-        return file_put_contents($fileName, $code);
+        return $this->writeFile($fileName, $code);
     }
 
     /**


### PR DESCRIPTION
Сейчас файловый кэш не использует каких-либо блокировок, поэтому возможна проблема со считыванием "грязных" данных их кэша, когда в это же время в него пишет другой процесс. Для предотвращения подобных ошибок предлагаю использовать трюк с переименованием файла, т.к. операция rename в linux в пределах одной файловой системы атомарна. 

Привожу результаты нагрузочного тестирования с помощью siege двух вариантов файлового кэша. Тестировал на php 5.5, opcache включен с дефолтными настройками, [код теста] (https://gist.github.com/silverslice/9b0a0ad555f073330be2) прилагаю.

Результат выполнения команды `siege -b -c 120 -r 100 http://bluz/cachetest/`:

* Базовый кэш:
```
Transactions:               11962 hits
Availability:               99.68 %
Elapsed time:               61.78 secs
Data transferred:            0.02 MB
Response time:               0.61 secs
Transaction rate:          193.62 trans/sec
Throughput:                  0.00 MB/sec
Concurrency:               118.52
Successful transactions:    11962
Failed transactions:           38
Longest transaction:         1.13
Shortest transaction:        0.01
```

* Доработанный кэш:
```
Transactions:               12000 hits
Availability:              100.00 %
Elapsed time:               65.38 secs
Data transferred:            0.00 MB
Response time:               0.65 secs
Transaction rate:          183.54 trans/sec
Throughput:                  0.00 MB/sec
Concurrency:               118.76
Successful transactions:    12000
Failed transactions:            0
Longest transaction:         1.24
Shortest transaction:        0.01
```