### PR TITLE
Hotfix for Session and Db\Row

### DIFF
--- a/src/Db/Row.php
+++ b/src/Db/Row.php
@@ -98,7 +98,7 @@ class Row implements \JsonSerializable, \ArrayAccess
      */
     public function __sleep()
     {
-        return array('primary', 'container', 'clean');
+        return array('container', 'clean');
     }
 
     /**

--- a/src/Proxy/Response.php
+++ b/src/Proxy/Response.php
@@ -73,7 +73,7 @@ use Bluz\View\View;
  * @method   static void  clearBody()
  * @see      Bluz\Response\AbstractResponse::clearBody()
  *
- * @method   static void  setCookie()
+ * @method   static void setCookie($name, $value = null, $expire = 0, $path = '/', $domain = null, $s = null, $h = null)
  * @see      Bluz\Response\AbstractResponse::setCookie($name, $value = null, $expire = 0, $path = '/', $domain = null,
  *              $secure = null, $httpOnly = null)
  * @method   static array getCookie()

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -155,7 +155,11 @@ class Session
      */
     public function regenerateId($deleteOldSession = true)
     {
-        return session_regenerate_id((bool) $deleteOldSession);
+        if ($this->sessionExists()) {
+            return session_regenerate_id((bool) $deleteOldSession);
+        } else {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Removed 'primary' from `Db\Row` magic `__sleep()`
Fixed Session regenerate Id behaviour for PHP 7