### PR TITLE
0.9.5

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -278,6 +278,26 @@ class Application
         Response::setInstance($response);
     }
 
+    protected function initView($module, $controller)
+    {
+        // $view for use in closure
+        $view = new View();
+
+        // setup additional helper path
+        $view->addHelperPath($this->getPath() . '/layouts/helpers');
+
+        // setup additional partial path
+        $view->addPartialPath($this->getPath() . '/layouts/partial');
+
+        // setup default path
+        $view->setPath($this->getPath() . '/modules/' . $module . '/views');
+
+        // setup default template
+        $view->setTemplate($controller . '.phtml');
+
+        return $view;
+    }
+
     /**
      * Process application
      *
@@ -486,20 +506,7 @@ class Application
         // process params
         $params = $reflection->params($params);
 
-        // $view for use in closure
-        $view = new View();
-
-        // setup additional helper path
-        $view->addHelperPath($this->getPath() . '/layouts/helpers');
-
-        // setup additional partial path
-        $view->addPartialPath($this->getPath() . '/layouts/partial');
-
-        // setup default path
-        $view->setPath($this->getPath() . '/modules/' . $module . '/views');
-
-        // setup default template
-        $view->setTemplate($controller . '.phtml');
+        $view = $this->initView($module, $controller);
 
         $bootstrapPath = $this->getPath() . '/modules/' . $module . '/bootstrap.php';
 

--- a/src/Common/Helper.php
+++ b/src/Common/Helper.php
@@ -54,8 +54,12 @@ trait Helper
      * @param string|array $helpersPath
      * @return self
      */
-    public function setHelpersPath($helpersPath)
+    public function setHelpersPath($helpersPath, $reset = false)
     {
+        if ($reset) {
+            $this->helpersPath = [];
+        }
+
         if (is_array($helpersPath)) {
             foreach ($helpersPath as $path) {
                 $this->addHelperPath((string)$path);


### PR DESCRIPTION
It would be usefull if view initialisation has it's own method. It is easy to override.
HelperPaths array always has at least one path that follows to Bluz directories. It woulds be great if we have an ability to substitute Bluz helper by our custom helper (which extends the Bluz's one) with the same name (a lot of usages of Bluz's one in application). To do it we need to setup our custom path to helper first in line in HelperPaths array but we cannot because both setHelperPaths and addHelpersPath only add.