### PR TITLE
Updated Db\Row\getRelations()

### DIFF
--- a/src/Application/Application.php
+++ b/src/Application/Application.php
@@ -292,6 +292,12 @@ class Application
         Response::setInstance($response);
     }
 
+    /**
+     * Initial controller view
+     * @param $module
+     * @param $controller
+     * @return View
+     */
     protected function initView($module, $controller)
     {
         // $view for use in closure

--- a/src/Common/Helper.php
+++ b/src/Common/Helper.php
@@ -54,12 +54,8 @@ trait Helper
      * @param string|array $helpersPath
      * @return self
      */
-    public function setHelpersPath($helpersPath, $reset = false)
+    public function setHelpersPath($helpersPath)
     {
-        if ($reset) {
-            $this->helpersPath = [];
-        }
-
         if (is_array($helpersPath)) {
             foreach ($helpersPath as $path) {
                 $this->addHelperPath((string)$path);
@@ -67,6 +63,16 @@ trait Helper
         } else {
             $this->addHelperPath((string)$helpersPath);
         }
+        return $this;
+    }
+
+    /**
+     * Reset helpers path
+     * @return self
+     */
+    public function resetHelpersPath()
+    {
+        $this->helpersPath = [];
         return $this;
     }
 

--- a/src/Db/Row.php
+++ b/src/Db/Row.php
@@ -487,14 +487,7 @@ class Row implements \JsonSerializable, \ArrayAccess
     public function getRelations($modelName)
     {
         if (!isset($this->relations[$modelName])) {
-            $relation = Relations::findRelation($this, $modelName);
-            if (empty($relation)) {
-                throw new RelationNotFoundException(
-                    'Can\'t found relation data for model "' . $modelName . '"'
-                );
-            } else {
-                $this->relations[$modelName] = $relation;
-            }
+            $this->relations[$modelName] = Relations::findRelation($this, $modelName);
         }
 
         return $this->relations[$modelName];

--- a/tests/src/Common/HelperTest.php
+++ b/tests/src/Common/HelperTest.php
@@ -108,4 +108,19 @@ class HelperTest extends TestCase
             self::MAGIC_NUMBER
         );
     }
+
+    /**
+     * test Reset Helper Path
+     * @expectedException \Bluz\Common\Exception\CommonException
+     */
+    public function testResetHelperPath()
+    {
+        $this->class->setHelpersPath(dirname(__FILE__) .'/Fixtures/Helper');
+        $this->class->resetHelpersPath();
+
+        $this->assertEquals(
+            $this->class->helperFunction(self::MAGIC_NUMBER),
+            self::MAGIC_NUMBER
+        );
+    }
 }


### PR DESCRIPTION
Updated method `Db\Row::getRelations()` - now it return empty array if linked entities not found
Added method `resetHelperPath()` for Helper trait
Added docblock for `initView()` method in Application