### PR TITLE
Move `resetInstance()` to Singleton

### DIFF
--- a/src/Common/Singleton.php
+++ b/src/Common/Singleton.php
@@ -45,6 +45,16 @@ trait Singleton
     }
 
     /**
+     * Reset instance
+     *
+     * @return void
+     */
+    public static function resetInstance()
+    {
+        static::$instance = null;
+    }
+
+    /**
      * Disabled by access level
      */
     private function __construct()

--- a/src/Proxy/ProxyTrait.php
+++ b/src/Proxy/ProxyTrait.php
@@ -35,16 +35,6 @@ trait ProxyTrait
     }
 
     /**
-     * Reset instance
-     *
-     * @return void
-     */
-    public static function resetInstance()
-    {
-        static::$instance = null;
-    }
-
-    /**
      * Handle dynamic, static calls to the object.
      *
      * @param  string $method

--- a/tests/src/BootstrapTest.php
+++ b/tests/src/BootstrapTest.php
@@ -41,16 +41,6 @@ class BootstrapTest extends Application
     protected $exception;
 
     /**
-     * resetRouter
-     *
-     * @return void
-     */
-    public function resetRouter()
-    {
-        $this->initRouter();
-    }
-
-    /**
      * Get dispatched module name
      *
      * @return string

--- a/tests/src/FrameworkTestCase.php
+++ b/tests/src/FrameworkTestCase.php
@@ -13,9 +13,6 @@ namespace Bluz\Tests;
 use Bluz;
 use Bluz\Http;
 use Bluz\Proxy;
-use Bluz\Proxy\Request;
-use Bluz\Request\RequestFactory;
-use Bluz\Router\Router;
 use Codeception\Test\Unit;
 use Zend\Diactoros\ServerRequest;
 
@@ -41,6 +38,7 @@ class FrameworkTestCase extends Unit
      */
     protected function setUp()
     {
+        self::getApp();
     }
 
     /**
@@ -115,7 +113,7 @@ class FrameworkTestCase extends Unit
 
         $request = self::prepareRequest($path, $query, $params, $method, $headers, $cookies);
 
-        Request::setInstance($request);
+        Proxy\Request::setInstance($request);
 
         return $request;
     }
@@ -126,27 +124,28 @@ class FrameworkTestCase extends Unit
     protected static function resetApp()
     {
         if (self::$app) {
-            self::$app->useLayout(true);
-            self::$app->resetRouter();
+            self::$app::resetInstance();
+            self::$app = null;
         }
 
-        Proxy\Auth::clearIdentity();
-        Proxy\Messages::popAll();
-        Proxy\Request::setInstance(RequestFactory::fromGlobals());
+        Proxy\Acl::resetInstance();
+        Proxy\Auth::resetInstance();
+        Proxy\Cache::resetInstance();
+        Proxy\Config::resetInstance();
+        Proxy\Db::resetInstance();
+        Proxy\EventManager::resetInstance();
+        Proxy\HttpCacheControl::resetInstance();
+        Proxy\Layout::resetInstance();
+        Proxy\Logger::resetInstance();
+        Proxy\Mailer::resetInstance();
+        Proxy\Messages::resetInstance();
+        Proxy\Registry::resetInstance();
+        Proxy\Request::resetInstance();
         Proxy\Request::resetAccept();
-        Proxy\Response::setInstance(new Bluz\Response\Response());
-    }
-
-    /**
-     * resetRouter
-     *
-     * @return void
-     */
-    protected static function resetRouter()
-    {
-        $router = new Router();
-        $router->setBaseUrl('/');
-        Proxy\Router::setInstance($router);
+        Proxy\Response::resetInstance();
+        Proxy\Router::resetInstance();
+        Proxy\Session::resetInstance();
+        Proxy\Translator::resetInstance();
     }
 
     /**

--- a/tests/unit/Application/ApplicationTest.php
+++ b/tests/unit/Application/ApplicationTest.php
@@ -26,6 +26,11 @@ use Zend\Diactoros\ServerRequest;
  */
 class ApplicationTest extends FrameworkTestCase
 {
+    public function testFullApplicationCircle()
+    {
+        self::markTestIncomplete('Need test for full circle of Application run');
+    }
+
     public function testGetApplicationPath()
     {
         self::assertEquals(dirname(__DIR__, 2), self::getApp()->getPath());
@@ -41,13 +46,36 @@ class ApplicationTest extends FrameworkTestCase
         self::assertInstanceOf(\Bluz\Response\Response::class, self::getApp()->getResponse());
     }
 
+    public function testPreProcessShouldDisableLayoutForAjaxRequests()
+    {
+        // setup Request
+        self::setRequestParams('', [], [], RequestMethod::GET, ['X-Requested-With' => 'XMLHttpRequest']);
+
+        // run Application
+        self::getApp()->process();
+
+        self::assertFalse(self::getApp()->useLayout());
+    }
+
+    public function testPreProcessShouldSwitchToJsonResponseForAcceptJsonHeader()
+    {
+        // setup Request
+        self::setRequestParams('', [], [], RequestMethod::GET, ['Accept' => Proxy\Request::TYPE_JSON]);
+
+        // run Application
+        self::getApp()->process();
+
+        self::assertFalse(self::getApp()->useLayout());
+        self::assertEquals('JSON', self::getApp()->getResponse()->getType());
+    }
+    
     /**
      * Test run Index Controller if Index Module
      */
     public function testIndexController()
     {
         // setup Request
-        self::setRequestParams('', [], [], RequestMethod::GET, ['Accept' => 'text/html']);
+        self::setRequestParams('', [], [], RequestMethod::GET, ['Accept' => Proxy\Request::TYPE_HTML]);
 
         // run Application
         self::getApp()->process();
@@ -62,7 +90,7 @@ class ApplicationTest extends FrameworkTestCase
     public function testErrorController()
     {
         // setup Request
-        self::setRequestParams(uniqid('module') . '/' . uniqid('controller'));
+        self::setRequestParams(uniqid('module', false) . '/' . uniqid('controller', false));
 
         // run Application
         self::getApp()->process();

--- a/tests/unit/Controller/ControllerTest.php
+++ b/tests/unit/Controller/ControllerTest.php
@@ -21,7 +21,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class ControllerTest extends FrameworkTestCase
 {
-
     /**
      * @var Controller\Controller
      */
@@ -33,14 +32,6 @@ class ControllerTest extends FrameworkTestCase
     public function setUp()
     {
         $this->controller = self::getApp()->dispatch('index', 'index');
-    }
-
-    /**
-     * Close all
-     */
-    public function tearDown()
-    {
-        self::resetApp();
     }
 
     public function testHelperAttachment()

--- a/tests/unit/Controller/Mapper/CrudTest.php
+++ b/tests/unit/Controller/Mapper/CrudTest.php
@@ -63,7 +63,6 @@ class CrudTest extends FrameworkTestCase
     public function testGetPrimaryKey()
     {
         self::setRequestParams('test/index', ['id' => 42], [], RequestMethod::GET);
-        self::resetRouter();
 
         $crudMapper = new Crud();
         $table = TableCrud::getInstance();
@@ -84,7 +83,6 @@ class CrudTest extends FrameworkTestCase
     public function testMethod($method)
     {
         self::setRequestParams('test/index', [], [], $method);
-        self::resetRouter();
 
         $crudMapper = new Crud();
         $crudMapper->setCrud(TableCrud::getInstance());
@@ -100,7 +98,6 @@ class CrudTest extends FrameworkTestCase
     public function testForbiddenMethod()
     {
         self::setRequestParams('test/index', [], [], RequestMethod::GET);
-        self::resetRouter();
 
         $crudMapper = new Crud();
         $crudMapper->setCrud(TableCrud::getInstance());

--- a/tests/unit/Db/DbTest.php
+++ b/tests/unit/Db/DbTest.php
@@ -34,6 +34,8 @@ class DbTest extends Bluz\Tests\FrameworkTestCase
      */
     public function setUp()
     {
+        parent::setUp();
+
         $this->db = new Db\Db();
         $this->db->setOptions(Proxy\Config::getData('db'));
     }
@@ -43,6 +45,8 @@ class DbTest extends Bluz\Tests\FrameworkTestCase
      */
     public function tearDown()
     {
+        parent::tearDown();
+
         $this->db->disconnect();
     }
 
@@ -81,6 +85,7 @@ class DbTest extends Bluz\Tests\FrameworkTestCase
     public function testFetchRow()
     {
         $result = $this->db->fetchRow("SELECT * FROM test LIMIT 1");
+        codecept_debug($result);
         self::assertCount(4, $result);
     }
 

--- a/tests/unit/Proxy/AclTest.php
+++ b/tests/unit/Proxy/AclTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class AclTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/AuthTest.php
+++ b/tests/unit/Proxy/AuthTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class AuthTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/CacheTest.php
+++ b/tests/unit/Proxy/CacheTest.php
@@ -21,11 +21,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class CacheTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstanceReturnFalse()
     {
         self::assertFalse(Proxy::getInstance());

--- a/tests/unit/Proxy/ConfigTest.php
+++ b/tests/unit/Proxy/ConfigTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class ConfigTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/DbTest.php
+++ b/tests/unit/Proxy/DbTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class DbTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/EventManagerTest.php
+++ b/tests/unit/Proxy/EventManagerTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class EventManagerTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/HttpCacheControlTest.php
+++ b/tests/unit/Proxy/HttpCacheControlTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class HttpCacheControlTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstanceReturnNilForCLI()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/LayoutTest.php
+++ b/tests/unit/Proxy/LayoutTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class LayoutTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/LoggerTest.php
+++ b/tests/unit/Proxy/LoggerTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class LoggerTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/MailerTest.php
+++ b/tests/unit/Proxy/MailerTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class MailerTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/MessagesTest.php
+++ b/tests/unit/Proxy/MessagesTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class MessagesTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/RegistryTest.php
+++ b/tests/unit/Proxy/RegistryTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class RegistryTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/RequestTest.php
+++ b/tests/unit/Proxy/RequestTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class RequestTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Request::resetInstance();
-    }
-
     /**
      * Test $_GET variables
      */

--- a/tests/unit/Proxy/ResponseTest.php
+++ b/tests/unit/Proxy/ResponseTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class ResponseTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Response::resetInstance();
-    }
-
     /**
      * Test Helper Redirect
      *

--- a/tests/unit/Proxy/RouterTest.php
+++ b/tests/unit/Proxy/RouterTest.php
@@ -22,15 +22,7 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class RouterTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
-    /**
-     * @expectedException \Bluz\Common\Exception\ComponentException
-     */
-    public function testLazyInitialInstanceShouldThrowError()
+    public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());
     }

--- a/tests/unit/Proxy/SessionTest.php
+++ b/tests/unit/Proxy/SessionTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class SessionTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/Proxy/TranslatorTest.php
+++ b/tests/unit/Proxy/TranslatorTest.php
@@ -22,11 +22,6 @@ use Bluz\Tests\FrameworkTestCase;
  */
 class TranslatorTest extends FrameworkTestCase
 {
-    protected function setUp()
-    {
-        Proxy::resetInstance();
-    }
-
     public function testGetProxyInstance()
     {
         self::assertInstanceOf(Target::class, Proxy::getInstance());

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -2,4 +2,4 @@
 // Here you can initialize variables that will be available to your tests
 // Emulate session
 $_SESSION = [];
-$_COOKIE[session_name()] = uniqid();
+$_COOKIE[session_name()] = uniqid('bluz-framework-test', false);


### PR DESCRIPTION
Refactoring tests:
- rebuild reset `Application`
- removed `resetRouter()`
- simplyfied `Proxy` tests