### PR TITLE
Enhance Travis CI test setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,12 @@ language: php
 php:
   - 7.2
   - 7.3
-  - master
+  - nightly
+services:
+  - mysql
 matrix:
   allow_failures:
-    - php: master
+    - php: nightly
 env:
   global:
     - secure: "QKyI/QO6H6pFE04Iz/4IcSuttMdY3o85mD2BTNV2Y2SeSPxLfuukqPrxjANrTc4GfI1v7/bZM43uMl3aRa76+HRZ83ZsXR8uv1VZUgNHYuoq7jdZb18BitM36h0LbHzTbYetJLiYg7l3mnbAezTXPXHfpNIWvZcuyZzatyF/lng="

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Easy to setup, easy to use.
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/bluzphp/main)
 
 ## Achievements
-[![PHP >= 7.1+](https://img.shields.io/packagist/php-v/bluzphp/framework.svg?style=flat)](https://php.net/)
+[![PHP >= 7.2+](https://img.shields.io/packagist/php-v/bluzphp/framework.svg?style=flat)](https://php.net/)
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/bluzphp/framework.svg?label=version&style=flat)](https://packagist.org/packages/bluzphp/framework)
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Lightweight PHP framework",
     "type": "library",
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2",
         "ext-PDO": "*",
         "ext-pdo_mysql": "*",
         "ext-json": "*",


### PR DESCRIPTION
# Changed log
- Since the [collection dependency](https://github.com/bluzphp/collection/blob/master/composer.json) requires `php-7.2` version at least, it also lets this framework require `php-7.2` version at least.
- Enhance Travis CI setting to define and install MySQL service.
- The master of PHP version will be experimental version, using the `php-nightly` version instead.
The `php-nightly` means a beta, unstable or preview version.